### PR TITLE
Fix source code language percentage displayed on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-home/files/config/nvim/autoload/* -linguist-detectable
+home/files/config/nvim/autoload/plug.vim -linguist-detectable
+home/files/config/nvim/autoload/plug.vim linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+home/files/config/nvim/autoload/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-home/files/config/nvim/autoload/plug.vim -linguist-detectable
-home/files/config/nvim/autoload/plug.vim linguist-vendored
+home/files/config/nvim/autoload/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-home/files/config/nvim/autoload/* linguist-vendored
+home/files/config/nvim/autoload/* -linguist-detectable


### PR DESCRIPTION
This should fix the misguiding language percentage which shows Vim script as the main language (because of the large nvim autoload file). The main language should be Scheme.